### PR TITLE
Datetime validations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'graphql'
 gem 'factory_bot_rails'
 gem 'faker'
 gem 'graphql-batch'
+gem 'validates_timeliness', '~> 5.0.0.beta1'
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (1.1.0)
     thread_safe (0.3.6)
+    timeliness (0.4.4)
     travis (1.10.0)
       faraday (~> 1.0)
       faraday_middleware (~> 1.0)
@@ -226,6 +227,8 @@ GEM
       pusher-client (~> 0.4)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
+    validates_timeliness (5.0.0)
+      timeliness (>= 0.3.10, < 1)
     websocket (1.2.9)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
@@ -262,6 +265,7 @@ DEPENDENCIES
   sprockets (~> 3)
   travis
   tzinfo-data
+  validates_timeliness (~> 5.0.0.beta1)
 
 RUBY VERSION
    ruby 2.5.3p105

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ For example, when attempting to add or update a record with an invalid datetime,
     {
       "message": "Validation failed: End time must be after 2021-08-23 18:30:00",
       "backtrace": [ ... ]
+    }
+  ]
+}
+    
 ```
 
 ## Queries

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 <img src="https://user-images.githubusercontent.com/69478485/115476368-f5a61700-a1fe-11eb-8d4a-8d5f7bdfd102.png" alt="CuraTour Logo" width="350" />
 
-CuraTour is an organizational scheduling app designed for Tour Managers of traveling entertainers. It is designed to work across device types and sizes for ease of use throughout a busy day, and includes functionality while in offline modes. Each user belongs to an organization, every organization can manage multiple tours. Within each tour, events are scheduled. These events may be concerts, press events, interviews, travel days, anything relevant for the tour. Each event can have an agenda for the day - a schedule for various parts of the day (load-in, sound check, doors-open, meet and greet, etc). Users can also manage pertinent contacts through the app, and use the app to connect directly to their contacts. CuraTour is here to make your life easier, and to help the show go on.
+CuraTour is an organizational scheduling app for Tour Managers of traveling entertainers. It is designed to work across device types and sizes for ease of use throughout a busy day, and includes functionality while in offline modes.
+
+Each user belongs to an organization, every organization can manage multiple tours. Within each tour, events are scheduled. These events may be concerts, press events, interviews, travel days, anything relevant for the tour. Each event can have an agenda for the day - a schedule for various parts of the day (load-in, sound check, doors-open, meet and greet, etc). Users can also manage pertinent contacts through the app, and use the app to connect directly to their contacts.
+
+CuraTour is here to make your life easier, and to help the show go on.
 
 # Curatour Backend — GraphQL API
 
@@ -114,7 +118,23 @@ phoneNumber: String!
 note: String
 ```
 
+## Error Handling
+
+When a GraphQL request fails, errors will be returned as a top level property in the GraphQL response.
+
+For example, when attempting to add or update a record with an invalid datetime, the API will respond with:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Validation failed: End time must be after 2021-08-23 18:30:00",
+      "backtrace": [ ... ]
+```
+
 ## Queries
+
+Below are available query endpoints. Per the above Types, queries can be nested to return relational data. See [Nested Query Examples](#nested-query-examples).
 
 ***
 
@@ -239,8 +259,8 @@ The Input Types below describes input requirements.
 
 For example, in `createEvent(input: CreateEventInput!): Event`, 
 
-- `CreateEventInput!` refers to the type defined below
-- `: Event` defines the Type to expect in the response
+- `CreateEventInput!` refers to the Input Type defined below
+- `: Event` defines the Query Type of the response
 
 ***
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,4 +4,5 @@ class Event < ApplicationRecord
   has_many :sub_events, dependent: :destroy
 
   validates_presence_of :name, :tour_id, :venue_id, :start_time, :end_time
+  validates_datetime :end_time, after: :start_time
 end

--- a/app/models/sub_event.rb
+++ b/app/models/sub_event.rb
@@ -2,4 +2,5 @@ class SubEvent < ApplicationRecord
   belongs_to :event
 
   validates_presence_of :name, :description, :event_id
+  validates_datetime :end_time, after: :start_time
 end

--- a/app/models/tour.rb
+++ b/app/models/tour.rb
@@ -3,4 +3,5 @@ class Tour < ApplicationRecord
   has_many :events
   
   validates_presence_of :name, :start_date, :end_date
+  validates_datetime :end_date, on_or_after: :start_date
 end

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,0 +1,40 @@
+ValidatesTimeliness.setup do |config|
+  # Extend ORM/ODMs for full support (:active_record included).
+  config.extend_orms = [ :active_record ]
+  #
+  # Default timezone
+  config.default_timezone = :utc
+  #
+  # Set the dummy date part for a time type values.
+  # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
+  #
+  # Ignore errors when restriction options are evaluated
+  # config.ignore_restriction_errors = false
+  #
+  # Re-display invalid values in date/time selects
+  # config.enable_date_time_select_extension!
+  #
+  # Handle multiparameter date/time values strictly
+  # config.enable_multiparameter_extension!
+  #
+  # Shorthand date and time symbols for restrictions
+  # config.restriction_shorthand_symbols.update(
+  #   :now   => lambda { Time.current },
+  #   :today => lambda { Date.current }
+  # )
+  #
+  # Use the plugin date/time parser which is stricter and extendable
+  # config.use_plugin_parser = false
+  #
+  # Add one or more formats making them valid. e.g. add_formats(:date, 'd(st|rd|th) of mmm, yyyy')
+  # config.parser.add_formats()
+  #
+  # Remove one or more formats making them invalid. e.g. remove_formats(:date, 'dd/mm/yyy')
+  # config.parser.remove_formats()
+  #
+  # Change the ambiguous year threshold when parsing a 2 digit year
+  # config.parser.ambiguous_year_threshold =  30
+  #
+  # Treat ambiguous dates, such as 01/02/1950, as a Non-US date.
+  # config.parser.remove_us_formats
+end

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,0 +1,16 @@
+en:
+  errors:
+    messages:
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/spec/graphql/mutations/events/create_event_spec.rb
+++ b/spec/graphql/mutations/events/create_event_spec.rb
@@ -29,7 +29,7 @@ module Mutations
             id: "#{Event.first.id}",
             name: "Lagrime New Zealand",
             startTime: "2021-04-20T20:44:46Z",
-            endTime: "2021-04-20T20:44:46Z",
+            endTime: "2021-04-20T22:45:00Z",
             tour: { "id": tour.id.to_s },
             venue: { "id": venue.id.to_s }
           )
@@ -41,7 +41,7 @@ module Mutations
               createEvent( input: {
                 name: "Lagrime New Zealand"
                 startTime: "2021-04-20T20:44:46Z"
-                endTime: "2021-04-20T20:44:46Z"
+                endTime: "2021-04-20T22:45:00Z"
                 tourId: #{tour_id}
                 venueId: #{venue_id}
               } ){

--- a/spec/graphql/mutations/sub_events/create_sub_event_spec.rb
+++ b/spec/graphql/mutations/sub_events/create_sub_event_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe Mutations::SubEvents::CreateSubEvent, type: :request do
               eventId: event.id,
               name: "New subevent",
               description: "We gotta do some stuff",
-              startTime: "2021-08-23T18:30:00-06:00",
-              endTime: "2021-08-23T21:30:00-06:00"
+              startTime: "2021-08-23T18:30:00Z",
+              endTime: "2021-08-23T21:30:00Z"
             }
           }
       end
@@ -48,8 +48,8 @@ RSpec.describe Mutations::SubEvents::CreateSubEvent, type: :request do
         expect(gql_response.data[mutation_type]).to eq({
             "name"=>"New subevent",
             "description"=>"We gotta do some stuff",
-            "startTime"=>"2021-08-24T00:30:00Z",
-            "endTime"=>"2021-08-24T03:30:00Z",
+            "startTime"=>"2021-08-23T18:30:00Z",
+            "endTime"=>"2021-08-23T21:30:00Z",
             "event"=>
               {
                 "id"=>event.id.to_s
@@ -70,6 +70,23 @@ RSpec.describe Mutations::SubEvents::CreateSubEvent, type: :request do
 
       it 'should return errors' do
         expect(gql_response.errors).to be_truthy
+      end
+    end
+    
+    context 'sad path where user input provides invalid end time' do
+      it 'should return errors' do
+        expect do 
+          mutation mutation_string,
+            variables: {
+              input: {
+                eventId: event.id,
+                name: "New subevent",
+                description: "We gotta do some stuff",
+                startTime: "2021-08-23T18:30:00Z",
+                endTime: "2021-08-23T17:30:00Z"
+              }
+            }
+        end.to raise_error ActiveRecord::RecordInvalid
       end
     end
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -28,7 +28,7 @@ describe Event do
             start_time: "2021-04-20T20:44:46Z",
             end_time: '2021-04-20T20:00:00Z'
         )
-      end.to raise_error
+      end.to raise_error ActiveRecord::RecordInvalid
     end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -13,5 +13,22 @@ describe Event do
     it { should validate_presence_of :venue_id }
     it { should validate_presence_of :start_time }
     it { should validate_presence_of :end_time }
+
+    it 'is invalid when end_time is before start_time' do
+      user = create(:user)
+      org = create(:organization, user_id: user.id)
+      venue = create(:venue)
+      tour = create(:tour, organization: org)
+      
+      expect do
+        create(
+          :event,
+            tour: tour,
+            venue: venue,
+            start_time: "2021-04-20T20:44:46Z",
+            end_time: '2021-04-20T20:00:00Z'
+        )
+      end.to raise_error
+    end
   end
 end

--- a/spec/models/tour_spec.rb
+++ b/spec/models/tour_spec.rb
@@ -10,5 +10,33 @@ describe Tour do
     it { should validate_presence_of :name }
     it { should validate_presence_of :start_date }
     it { should validate_presence_of :end_date }
+
+    it 'is valid when end_date is on_or_after start_date' do
+      user = create(:user)
+      org = create(:organization, user_id: user.id)
+      
+      expect do
+        create(
+          :tour,
+            organization: org,
+            start_date: "2021-04-20",
+            end_date: '2021-04-20'
+        )
+      end.to_not raise_error ActiveRecord::RecordInvalid
+    end
+    
+    it 'is invalid when end_date is before start_date' do
+      user = create(:user)
+      org = create(:organization, user_id: user.id)
+      
+      expect do
+        create(
+          :tour,
+            organization: org,
+            start_date: "2021-04-20",
+            end_date: '2021-04-19'
+        )
+      end.to raise_error ActiveRecord::RecordInvalid
+    end
   end
 end


### PR DESCRIPTION
## Purpose
- Add date & datetime validations to ensure `end_date` / `end_time` occurs after `start_date` / `end_time`
  - for Tours, `end_date` can be `on_or_after` `start_date` to account for 1-day Tours (column data type: Date)
  - For Events and SubEvents, `end_time` must be after `start_time` (column date type: DateTime)
- Update model validation specs to cover sad path invalid record errors
- Update README with error handling guidance

## Approach
- Used `validates_timeliness` gem

## Learning
- Explored ^ gem documentation: https://github.com/adzap/validates_timeliness